### PR TITLE
Feed & Like Feature Enhancements, Permission Control, and Documentation Updates

### DIFF
--- a/server/README.md
+++ b/server/README.md
@@ -334,10 +334,10 @@ image=@momo.jpg    ← 這裡的 @ 表示本地檔案
 
 ```bash
 curl -X POST http://localhost:8000/post/posts/ \
-  -H "Authorization: Bearer <你的 token>" \
-  -F "doll_id=doll001" \
-  -F "content=這是我的第一篇文" \
-  -F "image=@momo.jpg"
+  -H "Authorization: Bearer eyJ..f4" \
+  -F "doll_id=tomorin" \
+  -F "content=第一篇文OuOb" \
+  -F "image=@media/avatars/螢幕擷取畫面_2025-05-21_160025_H7YZH9c.png"
 ```
 
 ---
@@ -693,14 +693,11 @@ curl -X POST http://127.0.0.1:8000/core/dolls/ \
 
 # 建立貼文
 curl -X POST http://localhost:8000/post/posts/ \
-  -H "Content-Type: application/json" \
-  -H "Authorization: Bearer eyJ....Z7w" \
-  -d '{
-          "doll_id": "doll001",
-          "content": "第一篇文OuOb",
-          "image_url": "https://example.com/test-image.jpg"
-      }'
-# → {"id":"54005c5b-4d47-4b77-b6e5-d5448ec98f7d","doll_id":"doll001","content":"這是測試用的貼文內容","image_url":"https://example.com/test-image.jpg","created_at":"2025-05-05T13:59:54.4212}
+  -H "Authorization: Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJ0b2tlbl90eXBlIjoiYWNjZXNzIiwiZXhwIjoxNzQ5Mzc2NDg0LCJpYXQiOjE3NDkzNzI4ODQsImp0aSI6Ijg5ZGE1YTVlOGE0YjQyMzE4MjI3NDUwYjk2NWFkMDliIiwidXNlcl9pZCI6InJva3UifQ.nMVSnFTWA7dAR2pTE4Qp48QPNsZkkuUfPCBhIV8Zxf4" \
+  -F "doll_id=tomorin" \
+  -F "content=第一篇文OuOb" \
+  -F "image=@media/avatars/螢幕擷取畫面_2025-05-21_160025_H7YZH9c.png"
+# → {"id":"6b5319e6-76f8-4fd0-91c7-f834ef7785c1","doll_id":"tomorin","content":"第一篇文OuOb","image":"/media/avatars/%E8%9E%A2%E5%B9%95%E6%93%B7%E5%8F%96%E7%95%AB%E9%9D%A2_2025-05-21_160025_H7YZH9c_sr0PBMR.png","created_at":"2025-06-08T16:58:02.367721+08:00","like_count":0,"liked_by_me":false,"comment_count":0}
 
 # 確認可瀏覽的貼文
 curl -X GET "http://localhost:8000/post/feed/?doll_id=omuba"\

--- a/server/README.md
+++ b/server/README.md
@@ -535,57 +535,128 @@ curl -X GET "http://localhost:8000/post/feed/?doll_id=cheesetaro" \
 
 ---
 
-- **路徑**：`POST /post/posts/<uuid:post_id>/like/`
-- **說明**：按讚貼文
-- **請求格式範例（JSON）（post id 在 api 裡了）**：
+* **路徑**：`POST /post/posts/<uuid:post_id>/like/`
+
+* **說明**：
+
+  * 替貼文按讚
+  * 只有登入者本人擁有的娃娃（doll）可以進行按讚，**無法冒用他人娃娃按讚**（已實作權限驗證）
+
+* **請求格式範例（JSON）**：
 
 ```json
 {
-  "doll_id": "doll001",
+  "doll_id": "tomorin"
 }
 ```
-- **成功回應格式範例（JSON）**：
+
+**Curl 範例：**
+
+```bash
+curl -X POST \
+  -H "Authorization: Bearer <你的 token>" \
+  -H "Content-Type: application/json" \
+  -d '{"doll_id": "tomorin"}' \
+  http://localhost:8000/post/posts/6b5319e6-76f8-4fd0-91c7-f834ef7785c1/like/
+```
+
+* **成功回應格式範例（JSON）**：
 
 ```json
-{"message":"Liked"}
-{"message":"Already liked"}
+{
+  "message": "Liked",
+  "post": {
+    "id": "6b5319e6-76f8-4fd0-91c7-f834ef7785c1",
+    "doll_id": "tomorin",
+    "content": "第一篇文OuOb",
+    "image": "http://localhost:8000/media/avatars/%E8%9E%A2%E5%B9%95%E6%93%B7%E5%8F%96%E7%95%AB%E9%9D%A2_2025-05-21_160025_H7YZH9c_sr0PBMR.png",
+    "created_at": "2025-06-08T16:58:02.367721+08:00",
+    "like_count": 1,
+    "liked_by_me": true,
+    "comment_count": 0
+  }
+}
 ```
+
+```json
+{
+  "message": "Already liked",
+  "post": {
+    ... // 同上
+  }
+}
+```
+
+---
 
 ### 取消按讚貼文
 
 ---
 
 * **路徑**：`DELETE /post/posts/<uuid:post_id>/like/`
-* **說明**：取消按讚指定貼文
 
-- **請求格式範例（Curl 指令）**：
+* **說明**：
+
+  * 取消按讚指定貼文
+  * 只有登入者本人擁有的娃娃（doll）可以進行取消按讚，**無法冒用他人娃娃操作**（已實作權限驗證）
+
+* **請求格式範例（Curl 指令）**：
 
 ```bash
 curl -X DELETE \
-  -H "Authorization: Bearer <your_jwt_token>" \
+  -H "Authorization: Bearer <你的 token>" \
   -H "Content-Type: application/json" \
-  -d '{"doll_id": "cheesetaro"}' \
-  http://localhost:8000/post/posts/e6666593-3d06-4563-8b38-67a411476c3c/like/
+  -d '{"doll_id": "tomorin"}' \
+  http://localhost:8000/post/posts/6b5319e6-76f8-4fd0-91c7-f834ef7785c1/like/
 ```
 
-- **成功回應格式範例（JSON）**：
+* **成功回應格式範例（JSON）**：
 
 ```json
-[
-  {
-    "message": "Unliked",
-    "post": {
-      "id": "e6666593-3d06-4563-8b38-67a411476c3c",
-      "doll_id": "omuba",
-      "content": "我是一條笨狗 汪汪汪 我叫歐姆嘎抓",
-      "image_url": "https://github.com/",
-      "created_at": "2025-05-08T15:12:00.939363+08:00",
-      "like_count": 0,
-      "liked_by_me": false
-    }
+{
+  "message": "Unliked",
+  "post": {
+    "id": "6b5319e6-76f8-4fd0-91c7-f834ef7785c1",
+    "doll_id": "tomorin",
+    "content": "第一篇文OuOb",
+    "image": "http://localhost:8000/media/avatars/%E8%9E%A2%E5%B9%95%E6%93%B7%E5%8F%96%E7%95%AB%E9%9D%A2_2025-05-21_160025_H7YZH9c_sr0PBMR.png",
+    "created_at": "2025-06-08T16:58:02.367721+08:00",
+    "like_count": 0,
+    "liked_by_me": false,
+    "comment_count": 0
   }
-]
+}
 ```
+
+---
+
+#### **失敗時回應（JSON）**
+
+**權限錯誤（doll 不是自己的）：**
+
+```json
+{"detail": "你不能用不屬於你的娃娃按讚！"}
+```
+
+**已經沒按過讚：**
+
+```json
+{"message": "Not previously liked", "post": { ... }}
+```
+
+**未帶登入憑證（token）：**
+
+```json
+{"detail": "Authentication credentials were not provided."}
+```
+
+---
+
+#### **補充說明**
+
+* 只有自己擁有的娃娃 id 可以操作（權限驗證已上線）
+* 回傳內容會附帶該貼文的所有狀態欄位
+* 一律須帶 JWT token 驗證
 
 ---
 

--- a/server/README.md
+++ b/server/README.md
@@ -310,37 +310,91 @@ curl -X DELETE http://127.0.0.1:8000/core/follow/ \
 | 缺少必要欄位    | 400      | 缺少 from\_doll\_id 或 to\_doll\_id |
 
 ### 建立新貼文
+
 ---
-- **路徑**：`POST /post/posts/`
-- **說明**：建立新貼文
-- **請求格式範例（JSON）**：
+
+* **路徑**：`POST /post/posts/`
+* **說明**：
+
+  * 建立新貼文
+  * **只能使用自己擁有的娃娃（doll）發文，否則會被拒絕**
+  * 圖片需用「檔案格式」上傳（`multipart/form-data`），欄位名稱為 `image`
+
+---
+
+#### **請求格式範例（multipart/form-data）：**
+
+```
+doll_id=doll001
+content=這是我的第一篇文
+image=@momo.jpg    ← 這裡的 @ 表示本地檔案
+```
+
+**curl 範例：**
+
+```bash
+curl -X POST http://localhost:8000/post/posts/ \
+  -H "Authorization: Bearer <你的 token>" \
+  -F "doll_id=doll001" \
+  -F "content=這是我的第一篇文" \
+  -F "image=@momo.jpg"
+```
+
+---
+
+#### **成功回應格式範例（JSON）：**
 
 ```json
 {
+  "id": "54005c5b-4d47-4b77-b6e5-d5448ec98f7d",
   "doll_id": "doll001",
-  "content": "這是我的第一篇文",
-  "image_url": "https://example.com/momo.jpg"
+  "content": "這是測試用的貼文內容",
+  "image": "/media/avatars/momo.jpg",
+  "created_at": "2025-05-05T13:59:54.4212",
+  "like_count": 0,
+  "liked_by_me": false,
+  "comment_count": 0
 }
 ```
-- **成功回應格式範例（JSON）**：
+
+> 注意：`image` 會是上傳後的檔案路徑（通常是 `/media/avatars/檔案名`）
+
+---
+
+#### **失敗時回應（JSON）：**
+
+**缺少 content：**
 
 ```json
-{
-  "id":"54005c5b-4d47-4b77-b6e5-d5448ec98f7d",
-  "doll_id":"doll001",
-  "content":"這是測試用的貼文內容",
-  "image_url":"https://example.com/test-image.jpg",
-  "created_at":"2025-05-05T13:59:54.4212"
-}
+{"content": ["此欄位不可為空白。"]}
 ```
-- **失敗時回應（JSON）**：
+
+**缺少 image：**
 
 ```json
-缺少content
-{"content":["此欄位不可為空白。"]}
-缺少image
-{"image_url":["此欄位不可為空白。"]}
+{"image": ["此欄位不可為空白。"]}
 ```
+
+**doll 不是自己的（權限錯誤）：**
+
+```json
+{"detail": "你不能用不屬於你的娃娃發文！"}
+```
+
+**圖片欄位不是檔案格式：**
+
+```json
+{"image": ["提交的資料並不是檔案格式，請確認表單的編碼類型。"]}
+```
+
+---
+
+#### **補充說明**
+
+* `doll_id` 必須是登入者本人所擁有的娃娃 id
+* `image` 欄位必須上傳檔案（支援 jpg、jpeg、png、gif），**不能用網址或文字**
+* 請用 `multipart/form-data` 傳送
+
 ### 瀏覽貼文
 
 ---

--- a/server/README.md
+++ b/server/README.md
@@ -399,14 +399,65 @@ curl -X POST http://localhost:8000/post/posts/ \
 
 ---
 
-- **路徑**：`POST /post/feed/?doll_id=cheesetaro/`
-- **說明**：瀏覽貼文
+* **路徑**：`GET /post/feed/?doll_id=cheesetaro`
+* **說明**：
 
-- **成功回應格式範例（總之就是回傳可以看到的貼文資料，一次五篇，從有追蹤的優先顯示）**：
+  * 瀏覽 feed 貼文（只能查詢自己擁有的娃娃）
+  * 回傳一次最多 5 篇，優先顯示有追蹤的娃娃的貼文
+  * 必須帶上登入 token
+
+---
+
+#### **請求範例：**
+
+```bash
+curl -X GET "http://localhost:8000/post/feed/?doll_id=cheesetaro" \
+  -H "Authorization: Bearer <你的 token>"
+```
+
+---
+
+#### **成功回應格式範例（JSON）：**
 
 ```json
-[{"id":"7f65e081-1724-4650-ab1d-0df3a93bc633","doll_id":"tomorin","content":"ffffe","image_url":"https://github.com/","created_at":"2025-05-08T01:51:13.196400+08:00"},{"id":"e2a6177d-5296-44fc-a08d-9c074d446ea5","doll_id":"omuba","content":"fff","image_url":"https://github.com/","created_at":"2025-05-08T01:51:03.587402+08:00"}]
+[
+  {
+    "id": "64ef2849-7f8c-43aa-b088-5c1b5e831448",
+    "doll_id": "tomorin",
+    "content": "第一篇文OuOb",
+    "image": "/media/avatars/%E8%9E%A2%E5%B9%95%E6%93%B7%E5%8F%96%E7%95%AB%E9%9D%A2_2025-05-21_160025_H7YZH9c_BVV00yW.png",
+    "created_at": "2025-06-07T21:12:09.575028+08:00",
+    "like_count": 0,
+    "liked_by_me": false,
+    "comment_count": 0
+  }
+]
 ```
+
+---
+
+#### **失敗時回應（JSON）：**
+
+**未帶登入憑證（token）：**
+
+```json
+{"detail": "Authentication credentials were not provided."}
+```
+
+**doll\_id 不是自己的娃娃：**
+
+```json
+{"detail": "你不能查詢不是你的娃娃的貼文 feed"}
+```
+
+---
+
+#### **補充說明**
+
+* 這個 API 只允許查詢登入者本人的娃娃
+* 每個請求最多回傳 5 篇貼文，依據有追蹤的娃娃優先顯示
+* 若想看更多貼文，可以用 offset/分頁查詢
+
 ### 取得某隻娃娃的貼文（個人頁）
 
 ---

--- a/server/post/views.py
+++ b/server/post/views.py
@@ -75,7 +75,9 @@ class LikePostView(APIView):
 
     def post(self, request, post_id):
         doll_id = request.data.get('doll_id')
-        doll = get_object_or_404(Doll, id=doll_id)
+        doll = Doll.objects.filter(id=doll_id, username=request.user).first()
+        if not doll:
+            raise PermissionDenied("你不能用不屬於你的娃娃按讚！")
         post = get_object_or_404(Post, id=post_id)
         like, created = Likes.objects.get_or_create(doll_id=doll, post_id=post.id)
         serializer = PostSerializer(post, context={'request': request, 'doll_id': doll_id})
@@ -86,7 +88,9 @@ class LikePostView(APIView):
 
     def delete(self, request, post_id):
         doll_id = request.data.get('doll_id')
-        doll = get_object_or_404(Doll, id=doll_id)
+        doll = Doll.objects.filter(id=doll_id, username=request.user).first()
+        if not doll:
+            raise PermissionDenied("你不能用不屬於你的娃娃取消讚！")
         post = get_object_or_404(Post, id=post_id)
         deleted, _ = Likes.objects.filter(doll_id=doll, post_id=post.id).delete()
         serializer = PostSerializer(post, context={'request': request, 'doll_id': doll_id})
@@ -94,7 +98,7 @@ class LikePostView(APIView):
             return Response({'message': 'Unliked', 'post': serializer.data}, status=status.HTTP_200_OK)
         else:
             return Response({'message': 'Not previously liked', 'post': serializer.data}, status=status.HTTP_400_BAD_REQUEST)
-        
+
 class CommentListCreateView(generics.ListCreateAPIView):
     serializer_class = CommentSerializer
     permission_classes = [permissions.IsAuthenticated]

--- a/server/post/views.py
+++ b/server/post/views.py
@@ -16,9 +16,14 @@ from rest_framework.pagination import LimitOffsetPagination
 class PostCreateView(APIView):
     permission_classes = [permissions.IsAuthenticated]  # 需要登入
     def post(self, request):
+        doll_id = request.data.get('doll_id')
+        doll = Doll.objects.filter(id=doll_id, username=request.user).first()
+        if not doll:
+            raise PermissionDenied("你不能用不屬於你的娃娃發文！")
+
         serializer = PostSerializer(data=request.data)
         if serializer.is_valid():
-            serializer.save() 
+            serializer.save(doll_id=doll)
             return Response(serializer.data, status=status.HTTP_201_CREATED)
         return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
     

--- a/server/post/views.py
+++ b/server/post/views.py
@@ -36,7 +36,10 @@ class PostListView(ListAPIView):
         if not doll_id:
             return super().list(request, *args, **kwargs)
 
-        doll = get_object_or_404(Doll, id=doll_id)
+        doll = Doll.objects.filter(id=doll_id, username=request.user).first()
+        if not doll:
+            raise PermissionDenied('你不能查詢不是你的娃娃的貼文 feed')
+
         seen_ids = PostSeen.objects.filter(doll_id=doll).values_list('post_id', flat=True)
         followed_ids = Follow.objects.filter(from_doll_id=doll).values_list('to_doll_id', flat=True)
 
@@ -63,10 +66,10 @@ class PostListView(ListAPIView):
             PostSeen.objects.bulk_create(seen_objs, ignore_conflicts=True)
 
         return Response(data, status=status.HTTP_200_OK)
-
+    
     def get_queryset(self):
         return Post.objects.none()
-    
+
 class LikePostView(APIView):
     permission_classes = [permissions.IsAuthenticated]
 

--- a/server/post/views.py
+++ b/server/post/views.py
@@ -79,7 +79,7 @@ class LikePostView(APIView):
         if not doll:
             raise PermissionDenied("你不能用不屬於你的娃娃按讚！")
         post = get_object_or_404(Post, id=post_id)
-        like, created = Likes.objects.get_or_create(doll_id=doll, post_id=post.id)
+        like, created = Likes.objects.get_or_create(doll_id=doll, post_id=post)
         serializer = PostSerializer(post, context={'request': request, 'doll_id': doll_id})
         if created:
             return Response({'message': 'Liked', 'post': serializer.data}, status=status.HTTP_201_CREATED)
@@ -92,7 +92,7 @@ class LikePostView(APIView):
         if not doll:
             raise PermissionDenied("你不能用不屬於你的娃娃取消讚！")
         post = get_object_or_404(Post, id=post_id)
-        deleted, _ = Likes.objects.filter(doll_id=doll, post_id=post.id).delete()
+        deleted, _ = Likes.objects.filter(doll_id=doll, post_id=post).delete()
         serializer = PostSerializer(post, context={'request': request, 'doll_id': doll_id})
         if deleted:
             return Response({'message': 'Unliked', 'post': serializer.data}, status=status.HTTP_200_OK)


### PR DESCRIPTION
- Restrict post creation and like/unlike actions to dolls owned by the authenticated user
- Update API documentation and examples for add post, like, and delete post endpoints
- Prevent users from liking or unliking posts with dolls they do not own (security fix)
- Adjusted README and API documentation for all related endpoints
- Verified like and unlike functionality now works as expected