### PR TITLE
Adds doll avatar to comment serializer

### DIFF
--- a/server/post/serializers.py
+++ b/server/post/serializers.py
@@ -40,14 +40,28 @@ class CommentSerializer(serializers.ModelSerializer):
         queryset=Doll.objects.all(),
     )
 
+    doll_name = serializers.CharField(source='doll_id.name', read_only=True)
+    doll_avatar = serializers.SerializerMethodField()
+
+
     class Meta:
         model = Comment
-        fields = ['local_id', 'post_id', 'doll_id', 'content', 'created_at']
+        fields = ['local_id', 'post_id', 'doll_id','doll_avatar','content', 'created_at']
         read_only_fields = ['local_id', 'created_at']
 
+    def get_doll_avatar(self, obj):
+        if obj.doll_id and obj.doll_id.avatar_image:
+            request = self.context.get('request')
+            if request:
+                return request.build_absolute_uri(obj.doll_id.avatar_image.url)
+            return obj.doll_id.avatar_image.url
+        return None
+    
     def create(self, validated_data):
         comment = Comment.objects.create(**validated_data)
         return comment
+    
+    
 
 class LikesSerializer(serializers.ModelSerializer):
     doll_id = serializers.PrimaryKeyRelatedField(queryset=Doll.objects.all())

--- a/server/post/serializers.py
+++ b/server/post/serializers.py
@@ -46,7 +46,7 @@ class CommentSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = Comment
-        fields = ['local_id', 'post_id', 'doll_id', 'doll_avatar', 'content', 'created_at']
+        fields = ['local_id', 'post_id', 'doll_id', 'doll_name', 'doll_avatar','content', 'created_at']
         read_only_fields = ['local_id', 'created_at']
 
     def get_doll_avatar(self, obj):

--- a/server/post/serializers.py
+++ b/server/post/serializers.py
@@ -46,7 +46,7 @@ class CommentSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = Comment
-        fields = ['local_id', 'post_id', 'doll_id','doll_avatar','content', 'created_at']
+        fields = ['local_id', 'post_id', 'doll_id', 'doll_avatar', 'content', 'created_at']
         read_only_fields = ['local_id', 'created_at']
 
     def get_doll_avatar(self, obj):


### PR DESCRIPTION
Adds a `doll_avatar` field to the `CommentSerializer`.

- The avatar URL is retrieved from the associated doll's avatar image.
- If a request context is available, the avatar URL is built as an absolute URI.
- This allows clients to display the avatar of the doll that created the comment.